### PR TITLE
fix: broken link to graphiql

### DIFF
--- a/pages/developers.js
+++ b/pages/developers.js
@@ -77,7 +77,7 @@ const Developers = ({ developers }) => (
               FAQ
           </a>
         </Link>
-        <a className="button" href="/graphiql">
+        <a className="button" href="/graphql">
           API
         </a>
       </div>


### PR DESCRIPTION
apollo no longer bundles graphiql, instead uses this new tool which is directly available in /graphql

<!--